### PR TITLE
fix: strip UTF-8 BOM from settings files; require electron explicitly

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -273,7 +273,8 @@ export default class VaultNicknamePlugin extends Plugin {
         // TODO: This is at least one API that prevents support on mobile
         //       (thanks @joethei for identifying). Need to find a
         //       mobile - friendly alternative.
-        const vaults = electron.ipcRenderer.sendSync("vault-list");
+        // `electron` is not a global in the renderer; require it explicitly.
+        const vaults = require("electron").ipcRenderer.sendSync("vault-list");
 
         const menu = new Menu();
 
@@ -677,7 +678,12 @@ export default class VaultNicknamePlugin extends Plugin {
     }
 
     readUtf8FileSync(absoluteFilePath: string) : string {
-        return this.app.vault.adapter.fs.readFileSync(absoluteFilePath, 'utf8');
+        const content = this.app.vault.adapter.fs.readFileSync(absoluteFilePath, 'utf8');
+
+        // Strip a leading UTF-8 BOM (U+FEFF) if present. `JSON.parse` throws on
+        // a BOM, which otherwise breaks the vault switcher whenever any vault's
+        // settings file happens to be saved as UTF-8 with BOM.
+        return content.charCodeAt(0) === 0xFEFF ? content.slice(1) : content;
     }
 
     writeUtf8FileSync(absoluteFilePath: string, content: string) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "vault-nickname",
     "name": "Vault Nickname",
-    "version": "1.1.11",
+    "version": "1.1.12",
     "minAppVersion": "1.7.7",
     "description": "Override the vault's display name and/or title order. Intended to disambiguate vaults with the same folder name when adhering to a common folder structure between projects.",
     "author": "@rscopic",


### PR DESCRIPTION
 - readUtf8FileSync now strips a leading BOM (U+FEFF), fixing both onVaultSwitcherClicked and loadSettings.
- electron.ipcRenderer is now obtained via require("electron"); the bundle previously referenced `electron` as an undeclared global.
